### PR TITLE
Add Ender Staff subtitle to en_us

### DIFF
--- a/src/main/resources/assets/grapplemod/lang/en_us.json
+++ b/src/main/resources/assets/grapplemod/lang/en_us.json
@@ -549,5 +549,7 @@
     "text.autoconfig.grapplemod.option.options.grapplinghook.custom.rocket.rocket_force.@Tooltip": "How fast the rocket propels the player",
     "text.autoconfig.grapplemod.option.options.grapplinghook.custom.rocket.rocket_active_time.@Tooltip": "The time that the rocket can be used until it has to refuel (fuel auto-regenerates when it is not being used)",
     "text.autoconfig.grapplemod.option.options.grapplinghook.custom.rocket.rocket_refuel_ratio.@Tooltip": "The ratio of the time that the rocket takes to regenerate fuel, compared to the time the rocket is used. (e.g. 2.0 means a unit of fuel that takes 1 second to use up will take 2 seconds to regenerate. Lower is better. )",
-    "text.autoconfig.grapplemod.option.options.grapplinghook.custom.rocket.rocket_vertical_angle.@Tooltip": "The angle upwards that the rocket force is applied"
+    "text.autoconfig.grapplemod.option.options.grapplinghook.custom.rocket.rocket_vertical_angle.@Tooltip": "The angle upwards that the rocket force is applied",
+
+    "grapplemod.subtitle.enderstaff": "Ender Staff propels"
 }


### PR DESCRIPTION
This was tested in v1. My bad if v2 breaks it.
I noticed there was a missing subtitle string for the sound when you use the ender staff, this is just a fix to that.
I assume the devs dont use the subtitles feature? It lets u see the direction sounds r coming from, pretty useful.
I don't know any languages other than English, so please translate this for the other languages.